### PR TITLE
 本一覧APIni

### DIFF
--- a/api/helper/pagination.go
+++ b/api/helper/pagination.go
@@ -1,0 +1,24 @@
+package helper
+
+import (
+	"math"
+)
+
+func Pagination[T comparable](x []T, page int, perPage int) (data []T, currentPage int, lastPage int) {
+	lastPage = int(math.Ceil(float64(len(x)) / float64(perPage)))
+	currentPage = page
+
+	if page < 1 {
+		page = 1
+	} else if lastPage < page {
+		page = lastPage
+	}
+
+	if page == lastPage {
+		data = x[(page-1)*perPage:]
+	} else {
+		data = x[(page-1)*perPage : page*perPage]
+	}
+
+	return
+}


### PR DESCRIPTION
# 概要
本一覧画面の作成

# 修正点
- 本一覧画面の作成
- fetchのカスタムメソッド作成
- ヘッダーとフッターのディレクトリ構造変更
- hooksのディレクトリ構造変更
- コンポーネントのフォルダ名変更
- レイアウトファイルの修正
- BookCardコンポーネントの作成
- BookListコンポーネントの作成
- BorrowingModalの作成
- ヘッダーのボタンを太字に変更
- Paginationコンポーネント作成

# 動作確認
## 前提条件
- 本が最低でも3冊以上登録されていること（できれば51冊以上が望ましい）
- loanableがtrueの本と、falseの本が1冊以上登録されていること
- ログイン済みであること
- api側のブランチが「feature/books」になっていること

## 手順
- [ ] http://localhost:3000/books にアクセスして下記の画面が表示されることを確認する
- [ ] ヘッダーの本の一覧、本の登録、ログアウトの文字が太字になっていることを確認する
![スクリーンショット 2025-05-25 17 56 30](https://github.com/user-attachments/assets/af5f6b89-0422-4bcb-a9f9-519cfbe50adb)

- [ ] loanableがtrueの本は本の画像の下の借りるの文字が黒色、falseの本は借りるの文字がグレーになっていることを確認する
![スクリーンショット 2025-05-25 17 59 26](https://github.com/user-attachments/assets/cf30c2f7-22e0-4501-aacd-a77f784a2450)


- [ ] 黒字になっている借りるの文字をクリックすると下記のモーダルが表示されることを確認する
![スクリーンショット 2025-05-25 18 00 12](https://github.com/user-attachments/assets/d320e4ee-171b-4a77-9c52-27ccbf82807a)

- [ ] 先ほどのモーダルの閉じるをクリックしたら、モーダルが閉じることを確認する
- [ ] 画像をホバーすると本のタイトルが確認できることを確認する
- [ ] 画像が51冊以上ない場合はリポジトリのsrc/src/app/ui/books/BookList.tsxの35行目にあるPER_PAGEの定数は1ページに表示する本の数なので、3ページ以上になるように数字を調整する
- [ ] ブラウザに戻り、画面をリロードする
- [ ] ページネーションが2ページ以上になっていることを確認する
- [ ] 1ページ目にいる状態で左の矢印の部分がグレーになり、選択できない状態になっていることを確認する
![スクリーンショット 2025-05-25 18 04 26](https://github.com/user-attachments/assets/06d1f79a-a0f1-4533-ab55-aaa8a6b6e64b)

- [ ] 右矢印を選択し、ページが1ページずつずれることを確認する
- [ ] 最後のページまで移動すると右の矢印の部分がグレーになり、左の矢印が紺になって選択可能なことを確認する
