### PR TITLE
本の登録で貸し出し不可の本を登録できない不具合対応

### DIFF
--- a/api/controller/book_controller.go
+++ b/api/controller/book_controller.go
@@ -83,7 +83,7 @@ func GetBooks(context *gin.Context) {
 type CreateBookRequest struct {
 	Title    string `json:"title" binding:"required"`
 	ImageUrl string `json:"imageUrl" binding:"required"`
-	Loanable bool   `json:"loanable" binding:"required"`
+	Loanable bool   `json:"loanable"`
 }
 
 func CreateBook(c *gin.Context) {
@@ -142,7 +142,7 @@ func CreateBook(c *gin.Context) {
 type UpdateBookRequest struct {
 	Title    string `json:"title" binding:"required"`
 	ImageUrl string `json:"imageUrl" binding:"required"`
-	Loanable bool   `json:"loanable" binding:"required"`
+	Loanable bool   `json:"loanable"`
 }
 
 type UpdateBookResponse struct {


### PR DESCRIPTION
# 概要
本の登録で貸し出し不可の本を登録できない不具合対応

# 修正点
- 本の登録でloanableが必須条件になっていたがfalseはその必須条件のバリテーションに引っかかるので必須を解除

# 動作確認
## 前提条件
- ログイン済みであること

## 手順
- [ ] 本の登録APIを開き、bodyに登録情報を設定する
- [ ] loanableにfalseを設定して送信する
- [ ] HTTPメソッドが201で登録した本の情報が返ってくることを確認する
![スクリーンショット 2025-05-28 1 11 21](https://github.com/user-attachments/assets/583cf164-1c05-4c21-ab6b-014b8fdad19f)
