### PR TITLE
借りた本一覧APIにページネーション追加

### DIFF
--- a/api/controller/borrowed_book_controller.go
+++ b/api/controller/borrowed_book_controller.go
@@ -156,6 +156,6 @@ func GetBorrowedBooks(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"borrowed_books": response,
+		"borrowedBooks": response,
 	})
 }

--- a/api/controller/borrowed_book_controller.go
+++ b/api/controller/borrowed_book_controller.go
@@ -3,7 +3,9 @@ package controller
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/sayasurvey/golang/api/repository"
+	"github.com/sayasurvey/golang/api/helper"
 	"net/http"
+	"strconv"
 	"time"
 )
 
@@ -22,6 +24,13 @@ type BorrowedBookResponse struct {
 	ImageUrl      string `json:"imageUrl"`
 	CheckoutDate  string `json:"checkoutDate"`
 	ReturnDueDate string `json:"returnDueDate"`
+}
+
+type BorrowedBooksResponse struct {
+	BorrowedBooks []BorrowedBookResponse `json:"borrowedBooks"`
+	CurrentPage   int                    `json:"currentPage"`
+	LastPage      int                    `json:"lastPage"`
+	PerPage       int                    `json:"perPage"`
 }
 
 var borrowedBookRepo = repository.NewBorrowedBookRepository()
@@ -118,6 +127,21 @@ func ReturnBook(c *gin.Context) {
 }
 
 func GetBorrowedBooks(c *gin.Context) {
+	page := 1
+	perPage := 25
+
+	if pageStr := c.Query("page"); pageStr != "" {
+		if parsedPage, err := strconv.Atoi(pageStr); err == nil && parsedPage > 0 {
+			page = parsedPage
+		}
+	}
+
+	if perPageStr := c.Query("perPage"); perPageStr != "" {
+		if parsedPerPage, err := strconv.Atoi(perPageStr); err == nil && parsedPerPage > 0 {
+			perPage = parsedPerPage
+		}
+	}
+
 	userID, exists := c.Get("user_id")
 	if !exists {
 		c.JSON(http.StatusUnauthorized, gin.H{
@@ -155,7 +179,12 @@ func GetBorrowedBooks(c *gin.Context) {
 		}
 	}
 
-	c.JSON(http.StatusOK, gin.H{
-		"borrowedBooks": response,
+	paginatedBooks, currentPage, lastPage := helper.Pagination(response, page, perPage)
+
+	c.JSON(http.StatusOK, BorrowedBooksResponse{
+		BorrowedBooks: paginatedBooks,
+		CurrentPage:   currentPage,
+		LastPage:      lastPage,
+		PerPage:       perPage,
 	})
 }

--- a/api/helper/pagination.go
+++ b/api/helper/pagination.go
@@ -12,6 +12,8 @@ func Pagination[T comparable](x []T, page int, perPage int) (data []T, currentPa
 		page = 1
 	} else if lastPage < page {
 		page = lastPage
+		currentPage = page
+		return []T{}, currentPage, lastPage
 	}
 
 	if page == lastPage {


### PR DESCRIPTION
# 概要
借りた本一覧APIにページネーション機能追加
また、最後のページより大きいページ数を指定した際は本の一覧情報を空配列とする

# 修正点
- 借りた本一覧APIにページネーション機能追加
- 最後のページより大きいページ数を指定した場合は本の一覧情報を空配列で返す

# 動作確認
## 前提条件
- 借りた本が1冊以上あること

## 手順
### 最後のページより大きいページ数を指定した場合は本の情報を空配列で返す
- [ ] PostmanでCBM/Books/借りた本の一覧を開く
- [ ] データが登録されている最後のページをクエリパラメータのpageに指定し、リクエストを送信する
- [ ] 下記のようなデータが返っていることを確認する
```
{
    "borrowedBooks": [
        {
            "id": 25,
            "title": "test本",
            "imageUrl": "https://t3.ftcdn.net/jpg/02/36/99/22/240_F_236992283_sNOxCVQeFLd5pdqaKGh8DRGMZy7P4XKm.jpg",
            "checkoutDate": "2025-05-31",
            "returnDueDate": "2025-06-02"
        }
    ],
    "currentPage": 1,
    "lastPage": 1,
    "perPage": 25
}
```
- [ ] 最後のページ数から+1した値をクエリパラメータのpageに指定しリクエストを送信する
- [ ] 下記のようにborrowedBooksの項目が空配列になっていることを確認する
```
{
    "borrowedBooks": [],
    "currentPage": 1,
    "lastPage": 1,
    "perPage": 25
}
```