### PR TITLE
お気に入り機能にページネーション追加

### DIFF
--- a/api/controller/book_controller.go
+++ b/api/controller/book_controller.go
@@ -29,25 +29,25 @@ type BooksResponse struct {
 	PerPage     int           `json:"perPage"`
 }
 
-func GetBooks(context *gin.Context) {
+func GetBooks(c *gin.Context) {
 	page := 1
 	perPage := 50
 
-	if pageStr := context.Query("page"); pageStr != "" {
+	if pageStr := c.Query("page"); pageStr != "" {
 		if parsedPage, err := strconv.Atoi(pageStr); err == nil && parsedPage > 0 {
 			page = parsedPage
 		}
 	}
 
-	if perPageStr := context.Query("perPage"); perPageStr != "" {
+	if perPageStr := c.Query("perPage"); perPageStr != "" {
 		if parsedPerPage, err := strconv.Atoi(perPageStr); err == nil && parsedPerPage > 0 {
 			perPage = parsedPerPage
 		}
 	}
 
-	userID, exists := context.Get("user_id")
+	userID, exists := c.Get("user_id")
 	if !exists {
-		context.JSON(http.StatusUnauthorized, gin.H{
+		c.JSON(http.StatusUnauthorized, gin.H{
 			"error": "認証が必要です",
 		})
 		return
@@ -55,7 +55,7 @@ func GetBooks(context *gin.Context) {
 
 	books, err := repository.GetAllBooks()
 	if err != nil {
-		context.JSON(http.StatusInternalServerError, gin.H{
+		c.JSON(http.StatusInternalServerError, gin.H{
 			"error": "本の一覧取得に失敗しました",
 		})
 		return
@@ -64,7 +64,7 @@ func GetBooks(context *gin.Context) {
 	wishListRepo := repository.NewBorrowingWishListRepository()
 	wishList, err := wishListRepo.GetWishListByUserID(userID.(uint))
 	if err != nil {
-		context.JSON(http.StatusInternalServerError, gin.H{
+		c.JSON(http.StatusInternalServerError, gin.H{
 			"error": "お気に入り情報の取得に失敗しました",
 		})
 		return
@@ -97,7 +97,7 @@ func GetBooks(context *gin.Context) {
 
 	paginatedBooks, currentPage, lastPage := helper.Pagination(responseBooks, page, perPage)
 
-	context.JSON(http.StatusOK, BooksResponse{
+	c.JSON(http.StatusOK, BooksResponse{
 		Books:      paginatedBooks,
 		CurrentPage: currentPage,
 		LastPage:    lastPage,

--- a/api/controller/borrowed_book_controller.go
+++ b/api/controller/borrowed_book_controller.go
@@ -128,7 +128,7 @@ func ReturnBook(c *gin.Context) {
 
 func GetBorrowedBooks(c *gin.Context) {
 	page := 1
-	perPage := 25
+	perPage := 50
 
 	if pageStr := c.Query("page"); pageStr != "" {
 		if parsedPage, err := strconv.Atoi(pageStr); err == nil && parsedPage > 0 {


### PR DESCRIPTION
# 概要
お気に入りリストにページネーションの機能がなかったため追加
また、本一覧APIに本がお気に入り登録出されているかどうかのデータも返すように修正

# 修正点
- [ ] お気に入り一覧APIにページネーション機能追加
- [ ] 本一覧にお気に入りされているかどうかの項目追加
- [ ] リファクタリング

# 動作確認
## 前提条件
- お気に入り登録した本が2冊以上あること(51冊以上が望ましい)

## 手順
### お気に入り一覧のページネーションが機能していることを確認する
- [ ] Postmanでお気に入り一覧を開いてクエリパラメータのperPageを2ページ以上になるように調整する
- [ ] クエリパラメータのpageを1に指定してリクエストを送信する
- [ ] 下記のようなデータが返りcurrentPageが1になっていることを確認する
```
{
    "wishList": [
        {
            "id": 5,
            "title": "test本",
            "imageUrl": "https://t3.ftcdn.net/jpg/02/36/99/22/240_F_236992283_sNOxCVQeFLd5pdqaKGh8DRGMZy7P4XKm.jpg"
        }
    ],
    "currentPage": 1,
    "lastPage": 4,
    "perPage": 1
}
```
- [ ] クエリパラメータのpageを2に指定してリクエストを送信する
- [ ] currentPageが2になっており、1ページ目と違う本の情報が返ってきていることを確認する

### 本一覧でお気に入りされているかどうかの項目が追加されている
- [ ] Postmanで本の一覧を開いてリクエストを送信する
- [ ] 本の情報の中にisWishListという項目が追加されていることを確認する
```
{
    "id": 5,
    "title": "test本",
    "imageUrl": "https://t3.ftcdn.net/jpg/02/36/99/22/240_F_236992283_sNOxCVQeFLd5pdqaKGh8DRGMZy7P4XKm.jpg",
    "loanable": false,
    "isWishList": true,
    "user": {
        "id": 1,
        "name": "ユーザー名"
    }
},
```